### PR TITLE
Adding hocon settings support for default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ ln -s target/scala-2.11/hey-out ~/bin/hey
 ```
 
 ```text
-hey        
+hey                       
 Error: at least one of the supported commands should have been called
 hey 0.1
 Usage: hey [echo|ansible] [options] <args>...
 
-Command: echo <value>
-Prints the value from the process itself and again from OS echo command for process execution test purposes
-  <value>
   --version                Prints version information
   -vb, --verbosity <value>
                            defaults to full. any other value means silent
+Command: echo <value>
+Prints the value from the process itself and again from OS echo command for process execution test purposes
+  <value>
 Command: ansible [status|restart|stop] [options]
 ansible related commands
   -sg, --serverGroup <value>
@@ -82,6 +82,7 @@ Command: ansible restart
 (Re)starts those servers
 Command: ansible stop
 Stops those servers
+You can define default values for command options at the hocon file ~/.hey/hey.conf
 ```
 
 ## Roadmap
@@ -108,6 +109,7 @@ Stops those servers
 
 ## License
 
+```license
 MIT License
 
 Copyright (c) 2019 Oswaldo C. Dantas Jr
@@ -129,3 +131,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ nativeLinkStubs := true
 enablePlugins(ScalaNativePlugin)
 
 libraryDependencies += "com.github.scopt" %%% "scopt" % "4.0.0-RC2"
+libraryDependencies += "org.ekrich" %%% "sconfig" % "1.0.0"
 
 git.useGitDescribe := true
 organizationName := "Oswaldo C. Dantas Jr"

--- a/src/main/scala/IOUtil.scala
+++ b/src/main/scala/IOUtil.scala
@@ -1,0 +1,23 @@
+import java.nio.file.{Files, Path, Paths}
+
+object IOUtil {
+
+  def homePath: String = System.getProperty("user.home")
+
+  def fileExists(p: Path): Boolean = Files.exists(p) && Files.isRegularFile(p)
+
+  def fileExists(path: String): Boolean = fileExists(Paths.get(path))
+
+  def readBytes(path: String): Option[Array[Byte]] = {
+    val p = Paths.get(path)
+    if (Files.exists(p) && Files.isRegularFile(p)) {
+      Some(Files.readAllBytes(Paths.get(path)))
+    } else {
+      None
+    }
+  }
+
+  def readString(path: String): Option[String] =
+    readBytes(path).map(new String(_))
+
+}

--- a/src/main/scala/Settings.scala
+++ b/src/main/scala/Settings.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Oswaldo C. Dantas Jr
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import org.ekrich.config.{Config, ConfigFactory}
+import Settings.implicits._
+
+object Settings {
+
+  private def readConfig(path: String): Option[Config] =
+    IOUtil.readString(path).map(ConfigFactory.parseString)
+
+  def read(path: String): Option[Settings] =
+    readConfig(path).map(new Settings(_))
+
+  object implicits {
+
+    implicit class RichConfig(val underlying: Config) extends AnyVal {
+      def getOptionalBoolean(path: String): Option[Boolean] =
+        optional(path, underlying.getBoolean)
+
+      def getOptionalString(path: String): Option[String] =
+        optional(path, underlying.getString)
+
+      def getStringOrElse(path: String, default: => String): String =
+        getOrElse(path, underlying.getString, default)
+
+      private def optional[T](path: String, f: (String) => T): Option[T] =
+        if (underlying.hasPath(path)) {
+          Some(f(path))
+        } else {
+          None
+        }
+
+      private def getOrElse[T](
+          path: String,
+          f: (String) => T,
+          default: => T
+      ): T =
+        optional(path, f).getOrElse(default)
+    }
+
+  }
+}
+
+class Settings(config: Config = ConfigFactory.empty()) {
+  val defaultServerGroup =
+    config.getStringOrElse("hey.defaults.serverGroup", "")
+  val defaultServiceName =
+    config.getStringOrElse("hey.defaults.serviceName", "")
+
+}


### PR DESCRIPTION
This allows calling `hey ansible status`, ommiting the server group and service name, which will be looked up from ~/.hey/hey.conf

Signed-off-by: Oswaldo Dantas <oswaldodantas@gmail.com>